### PR TITLE
Enable language feature: object[] memory to object[] storage

### DIFF
--- a/script/DeployL2Contracts.s.sol
+++ b/script/DeployL2Contracts.s.sol
@@ -1,6 +1,6 @@
 // Copyright Immutable Pty Ltd 2018 - 2025
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity ^0.8.28;
 
 import "../src/verifiers/accounts/AccountProofVerifier.sol";
 import "../src/verifiers/vaults/VaultEscapeProofVerifier.sol";


### PR DESCRIPTION
Change the Solidity version to enable copying from arrays of memory objects to arrays of storage objects:

        assetMappings = abi.decode(vm.parseJson(config, "$.asset_mappings"), (BridgedTokenMapping.TokenMapping[]));
