### PR TITLE
Minor improvements to validations and natspec

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -1,0 +1,14 @@
+{
+  "lib/axelar-cgp-solidity": {
+    "rev": "b323ae613a4286e4849bbf81dd8922e80fe4fdca"
+  },
+  "lib/axelar-gmp-sdk-solidity": {
+    "rev": "00682b6c3db0cc922ec0c4ea3791852c93d7ae31"
+  },
+  "lib/forge-std": {
+    "rev": "77041d2ce690e692d6e03cc812b57d1ddaa4d505"
+  },
+  "lib/openzeppelin-contracts": {
+    "rev": "e4f70216d759d8e6a64144a9e1f7bbeed78e7079"
+  }
+}

--- a/src/assets/BridgedTokenMapping.sol
+++ b/src/assets/BridgedTokenMapping.sol
@@ -63,6 +63,12 @@ abstract contract BridgedTokenMapping {
     /// @notice Mapping of Immutable X asset IDs to their corresponding asset details
     mapping(uint256 idOnX => TokenMapping) public assetMappings;
 
+    /**
+     * @notice Registers mappings between Immutable X asset IDs and their corresponding zkEVM token addresses
+     * @dev Only accounts with TOKEN_MAPPING_MANAGER role can call this function
+     * @dev Each asset can only be registered once; attempts to re-register will revert
+     * @param assetsDetails Array of token mappings containing Immutable X token details and zkEVM addresses
+     */
     function registerTokenMappings(TokenMapping[] calldata assetsDetails) external virtual;
 
     /**
@@ -104,6 +110,7 @@ abstract contract BridgedTokenMapping {
     /**
      * @notice Registers a new asset mapping.
      * @dev This function is internal and can be called by derived contracts to register a new asset mapping.
+     * @dev NOTE: A token can only be registered once, so ensuring the correctness of values is important.
      * @param tokenMapping The details of the asset to register, including its Immutable X ID, quantum, and corresponding zkEVM address.
      */
     function _registerTokenMapping(TokenMapping calldata tokenMapping) private {

--- a/src/bridge/starkex/LegacyStarkExchangeBridge.sol
+++ b/src/bridge/starkex/LegacyStarkExchangeBridge.sol
@@ -60,6 +60,7 @@ abstract contract LegacyStarkExchangeBridge is MainStorage {
         uint256 assetId = assetType;
         // Fetch and clear quantized amount.
         uint256 quantizedAmount = pendingWithdrawals[ownerKey][assetId];
+        require(quantizedAmount > 0, "NO_PENDING_WITHDRAWAL");
         pendingWithdrawals[ownerKey][assetId] = 0;
 
         // Transfer funds.

--- a/src/bridge/starkex/LegacyStarkExchangeBridge.sol
+++ b/src/bridge/starkex/LegacyStarkExchangeBridge.sol
@@ -184,11 +184,7 @@ abstract contract LegacyStarkExchangeBridge is MainStorage {
      * @return amount The non-quantized amount
      * @dev Reverts if dequantization would overflow
      */
-    function _fromQuantized(uint256 presumedAssetType, uint256 quantizedAmount)
-        internal
-        view
-        returns (uint256 amount)
-    {
+    function _fromQuantized(uint256 presumedAssetType, uint256 quantizedAmount) internal view returns (uint256 amount) {
         uint256 quantum = getQuantum(presumedAssetType);
         amount = quantizedAmount * quantum;
     }
@@ -259,11 +255,10 @@ abstract contract LegacyStarkExchangeBridge is MainStorage {
      */
     function _extractTokenSelectorFromAssetInfo(bytes memory assetInfo) private pure returns (bytes4 selector) {
         assembly {
-            selector :=
-                and(
-                    0xffffffff00000000000000000000000000000000000000000000000000000000,
-                    mload(add(assetInfo, SELECTOR_OFFSET))
-                )
+            selector := and(
+                0xffffffff00000000000000000000000000000000000000000000000000000000,
+                mload(add(assetInfo, SELECTOR_OFFSET))
+            )
         }
     }
 

--- a/src/bridge/starkex/StarkExchangeMigration.sol
+++ b/src/bridge/starkex/StarkExchangeMigration.sol
@@ -18,12 +18,7 @@ import {LegacyStarkExchangeBridge} from "./LegacyStarkExchangeBridge.sol";
  *      2. Enables an authorised entity to migrate ERC-20 tokens and ETH held by the StarkExchange bridge to Immutable zkEVM.
  *      3. Enables users who had already initiated a withdrawal from Immutable X, prior to this contract upgrade taking effect, to finalise their pending withdrawal.
  */
-contract StarkExchangeMigration is
-    IStarkExchangeMigration,
-    LegacyStarkExchangeBridge,
-    Initializable,
-    ReentrancyGuard
-{
+contract StarkExchangeMigration is IStarkExchangeMigration, LegacyStarkExchangeBridge, Initializable, ReentrancyGuard {
     /**
      * @notice Restrict access only to the migration manager
      */
@@ -43,8 +38,12 @@ contract StarkExchangeMigration is
      * @dev The hash of the data used to initialize the contract is pre-committed to when the contract upgrade is proposed in the Proxy's timelock upgrade.
      */
     function initialize(bytes calldata data) external initializer {
-        (address _migrationManager, address _zkEVMBridge, address _rootSenderAdapter, address _zkEVMWithdrawalProcessor)
-        = abi.decode(data, (address, address, address, address));
+        (
+            address _migrationManager,
+            address _zkEVMBridge,
+            address _rootSenderAdapter,
+            address _zkEVMWithdrawalProcessor
+        ) = abi.decode(data, (address, address, address, address));
 
         require(_migrationManager != address(0), InvalidAddress());
         require(_zkEVMBridge != address(0), InvalidAddress());

--- a/src/bridge/starkex/libraries/Common.sol
+++ b/src/bridge/starkex/libraries/Common.sol
@@ -47,8 +47,10 @@ library Addresses {
     */
     function validateContractId(address contractAddress, bytes32 expectedIdHash) internal {
         require(isContract(contractAddress), "ADDRESS_NOT_CONTRACT");
-        (bool success, bytes memory returndata) = contractAddress.call( // NOLINT: low-level-calls.
-        abi.encodeWithSignature("identify()"));
+        (bool success, bytes memory returndata) =
+            contractAddress.call( // NOLINT: low-level-calls.
+                abi.encodeWithSignature("identify()")
+            );
         require(success, "FAILED_TO_IDENTIFY_CONTRACT");
         string memory realContractId = abi.decode(returndata, (string));
         require(keccak256(abi.encodePacked(realContractId)) == expectedIdHash, "UNEXPECTED_CONTRACT_IDENTIFIER");

--- a/src/verifiers/accounts/AccountProofVerifier.sol
+++ b/src/verifiers/accounts/AccountProofVerifier.sol
@@ -13,7 +13,7 @@ import {Hashes} from "@openzeppelin/contracts/utils/cryptography/Hashes.sol";
  *      This creates a theoretical collision risk if a user's starkKey < 2^160. However, this risk is mitigated by:
  *      (1) Withdrawals are executed by a trusted DISBURSER_ROLE, not directly by users - attackers cannot exploit directly.
  *      (2) The account Merkle tree is generated off-chain by trusted infrastructure - attackers cannot insert collisions.
- *      (3) The probability of a starkKey being < 2^160 is ~2^-91 (cryptographically negligible).
+ *      (3) The probability of this collision is negligible.
  */
 abstract contract AccountProofVerifier {
     /// @notice Thrown when the provided account proof is invalid or malformed

--- a/src/verifiers/vaults/VaultEscapeProofVerifier.sol
+++ b/src/verifiers/vaults/VaultEscapeProofVerifier.sol
@@ -225,12 +225,11 @@ contract VaultEscapeProofVerifier is IVaultProofVerifier {
                     // aZ' = sD*xD.
                     aZ := mulmod(sD, xD, PRIME)
                     // aY' = sN*(bX * xD - xN) - bY*z = -bY * z + sN * (-xN + xD*bX).
-                    aY :=
-                        addmod(
-                            sub(PRIME, mulmod(bY, aZ, PRIME)),
-                            mulmod(sN, add(sub(PRIME, xN), mulmod(xD, bX, PRIME)), PRIME),
-                            PRIME
-                        )
+                    aY := addmod(
+                        sub(PRIME, mulmod(bY, aZ, PRIME)),
+                        mulmod(sN, add(sub(PRIME, xN), mulmod(xD, bX, PRIME)), PRIME),
+                        PRIME
+                    )
 
                     // As the value of the affine x coordinate is xN/xD and z=sD*xD,
                     // the projective x coordinate is xN*sD.
@@ -322,8 +321,10 @@ contract VaultEscapeProofVerifier is IVaultProofVerifier {
             proof := add(proof, 0x20)
             starkKey := shr(4, mload(proof))
             assetId := and(mload(add(proof, 0x1f)), 0x0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
-            quantizedAmount :=
-                and(mload(add(proof, 0x5f)), 0x0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+            quantizedAmount := and(
+                mload(add(proof, 0x5f)),
+                0x0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            )
         }
 
         require(starkKey != 0 && starkKey < K_MODULUS, InvalidVaultProof("Invalid Stark key."));

--- a/src/withdrawals/VaultWithdrawalProcessor.sol
+++ b/src/withdrawals/VaultWithdrawalProcessor.sol
@@ -23,10 +23,9 @@ contract VaultWithdrawalProcessor is
     AccountProofVerifier,
     BridgedTokenMapping
 {
-    /// @notice Enable or disable overriding of account and vault roots
-    /// @param oldValue prior value
-    /// @param newValue new value for override flag. True indicates override enabled.
-    event RootOverrideSet(bool oldValue, bool newValue);
+    /// @notice Emitted when the root override setting is changed
+    /// @param newValue The new value for the override flag. True indicates override enabled.
+    event RootOverrideSet(bool newValue);
 
     /// @notice Thrown if attempting to set the root override value to the existing value
     error NoChangeInOverrideValue();
@@ -145,9 +144,8 @@ contract VaultWithdrawalProcessor is
      */
     function setRootOverrideAllowed(bool allowed) external onlyRole(DEFAULT_ADMIN_ROLE) {
         require(rootOverrideAllowed != allowed, NoChangeInOverrideValue());
-        bool oldAllowed = rootOverrideAllowed;
         rootOverrideAllowed = allowed;
-        emit RootOverrideSet(oldAllowed, allowed);
+        emit RootOverrideSet(allowed);
     }
 
     /**

--- a/src/withdrawals/VaultWithdrawalProcessor.sol
+++ b/src/withdrawals/VaultWithdrawalProcessor.sol
@@ -124,8 +124,17 @@ contract VaultWithdrawalProcessor is
         _setAccountRoot(newRoot, rootOverrideAllowed);
     }
 
+    /**
+     * @notice Enables or disables the ability to override vault and account roots after initial setting
+     * @dev Only accounts with DEFAULT_ADMIN_ROLE can call this function
+     * @dev Reverts if the new value is the same as the current value
+     * @param allowed True to allow root overrides, false to lock roots after first setting
+     */
     function setRootOverrideAllowed(bool allowed) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(rootOverrideAllowed != allowed, NoChangeInOverrideValue());
+        bool oldAllowed = rootOverrideAllowed;
         rootOverrideAllowed = allowed;
+        emit RootOverrideSet(oldAllowed, allowed);
     }
 
     function registerTokenMappings(TokenMapping[] calldata assets) external override onlyRole(TOKEN_MAPPING_MANAGER) {

--- a/test/integration/bridge/starkex/StarkExchangeMigration.t.sol
+++ b/test/integration/bridge/starkex/StarkExchangeMigration.t.sol
@@ -95,9 +95,7 @@ contract StarkExchangeMigrationTest is Test {
         IStarkExchangeMigration.TokenMigrationDetails[] memory asset =
             new IStarkExchangeMigration.TokenMigrationDetails[](1);
         asset[0] = IStarkExchangeMigration.TokenMigrationDetails({
-            token: address(0xeee),
-            amount: migrateAmount,
-            bridgeFee: BRIDGE_FEE
+            token: address(0xeee), amount: migrateAmount, bridgeFee: BRIDGE_FEE
         });
 
         starkExProxy.migrateHoldings{value: bridgeFee}(asset);
@@ -130,9 +128,7 @@ contract StarkExchangeMigrationTest is Test {
             IStarkExchangeMigration.TokenMigrationDetails[] memory assets =
                 new IStarkExchangeMigration.TokenMigrationDetails[](1);
             assets[0] = IStarkExchangeMigration.TokenMigrationDetails({
-                token: address(token),
-                amount: initStarkExBal,
-                bridgeFee: bridgeFee
+                token: address(token), amount: initStarkExBal, bridgeFee: bridgeFee
             });
 
             starkExProxy.migrateHoldings{value: bridgeFee}(assets);

--- a/test/unit/bridge/starkex/StarkExchangeMigration.t.sol
+++ b/test/unit/bridge/starkex/StarkExchangeMigration.t.sol
@@ -221,9 +221,7 @@ contract StarkExchangeMigrationTest is Test {
         IStarkExchangeMigration.TokenMigrationDetails[] memory assets =
             new IStarkExchangeMigration.TokenMigrationDetails[](1);
         assets[0] = IStarkExchangeMigration.TokenMigrationDetails({
-            token: starkExBridge.NATIVE_ETH(),
-            amount: ethAmount,
-            bridgeFee: BRIDGE_FEE
+            token: starkExBridge.NATIVE_ETH(), amount: ethAmount, bridgeFee: BRIDGE_FEE
         });
 
         vm.deal(address(starkExBridge), ethAmount);
@@ -241,9 +239,7 @@ contract StarkExchangeMigrationTest is Test {
         IStarkExchangeMigration.TokenMigrationDetails[] memory assets =
             new IStarkExchangeMigration.TokenMigrationDetails[](1);
         assets[0] = IStarkExchangeMigration.TokenMigrationDetails({
-            token: address(testToken),
-            amount: tokenAmount,
-            bridgeFee: BRIDGE_FEE
+            token: address(testToken), amount: tokenAmount, bridgeFee: BRIDGE_FEE
         });
 
         deal(address(testToken), address(starkExBridge), tokenAmount);
@@ -268,14 +264,10 @@ contract StarkExchangeMigrationTest is Test {
         IStarkExchangeMigration.TokenMigrationDetails[] memory assets =
             new IStarkExchangeMigration.TokenMigrationDetails[](2);
         assets[0] = IStarkExchangeMigration.TokenMigrationDetails({
-            token: starkExBridge.NATIVE_ETH(),
-            amount: ethAmount,
-            bridgeFee: BRIDGE_FEE
+            token: starkExBridge.NATIVE_ETH(), amount: ethAmount, bridgeFee: BRIDGE_FEE
         });
         assets[1] = IStarkExchangeMigration.TokenMigrationDetails({
-            token: address(testToken),
-            amount: tokenAmount,
-            bridgeFee: BRIDGE_FEE
+            token: address(testToken), amount: tokenAmount, bridgeFee: BRIDGE_FEE
         });
 
         vm.deal(address(starkExBridge), ethAmount);
@@ -311,9 +303,7 @@ contract StarkExchangeMigrationTest is Test {
         IStarkExchangeMigration.TokenMigrationDetails[] memory assets =
             new IStarkExchangeMigration.TokenMigrationDetails[](1);
         assets[0] = IStarkExchangeMigration.TokenMigrationDetails({
-            token: starkExBridge.NATIVE_ETH(),
-            amount: ethAmount,
-            bridgeFee: BRIDGE_FEE
+            token: starkExBridge.NATIVE_ETH(), amount: ethAmount, bridgeFee: BRIDGE_FEE
         });
 
         vm.deal(UNAUTHORIZED_ADDRESS, 2 ether);
@@ -340,8 +330,9 @@ contract StarkExchangeMigrationTest is Test {
     function test_RevertIf_MigrateHoldings_ZeroAmount() public {
         IStarkExchangeMigration.TokenMigrationDetails[] memory assets =
             new IStarkExchangeMigration.TokenMigrationDetails[](1);
-        assets[0] =
-            IStarkExchangeMigration.TokenMigrationDetails({token: address(testToken), amount: 0, bridgeFee: BRIDGE_FEE});
+        assets[0] = IStarkExchangeMigration.TokenMigrationDetails({
+            token: address(testToken), amount: 0, bridgeFee: BRIDGE_FEE
+        });
 
         vm.prank(MIGRATION_MANAGER);
         vm.expectRevert(IStarkExchangeMigration.InvalidAmount.selector);
@@ -353,9 +344,7 @@ contract StarkExchangeMigrationTest is Test {
         IStarkExchangeMigration.TokenMigrationDetails[] memory assets =
             new IStarkExchangeMigration.TokenMigrationDetails[](1);
         assets[0] = IStarkExchangeMigration.TokenMigrationDetails({
-            token: address(testToken),
-            amount: excessiveAmount,
-            bridgeFee: BRIDGE_FEE
+            token: address(testToken), amount: excessiveAmount, bridgeFee: BRIDGE_FEE
         });
 
         vm.prank(MIGRATION_MANAGER);
@@ -368,9 +357,7 @@ contract StarkExchangeMigrationTest is Test {
         IStarkExchangeMigration.TokenMigrationDetails[] memory assets =
             new IStarkExchangeMigration.TokenMigrationDetails[](1);
         assets[0] = IStarkExchangeMigration.TokenMigrationDetails({
-            token: starkExBridge.NATIVE_ETH(),
-            amount: excessiveAmount,
-            bridgeFee: BRIDGE_FEE
+            token: starkExBridge.NATIVE_ETH(), amount: excessiveAmount, bridgeFee: BRIDGE_FEE
         });
 
         vm.prank(MIGRATION_MANAGER);
@@ -383,9 +370,7 @@ contract StarkExchangeMigrationTest is Test {
         IStarkExchangeMigration.TokenMigrationDetails[] memory assets =
             new IStarkExchangeMigration.TokenMigrationDetails[](1);
         assets[0] = IStarkExchangeMigration.TokenMigrationDetails({
-            token: address(testToken),
-            amount: tokenAmount,
-            bridgeFee: BRIDGE_FEE
+            token: address(testToken), amount: tokenAmount, bridgeFee: BRIDGE_FEE
         });
 
         vm.prank(MIGRATION_MANAGER);
@@ -398,9 +383,7 @@ contract StarkExchangeMigrationTest is Test {
         IStarkExchangeMigration.TokenMigrationDetails[] memory assets =
             new IStarkExchangeMigration.TokenMigrationDetails[](1);
         assets[0] = IStarkExchangeMigration.TokenMigrationDetails({
-            token: address(testToken),
-            amount: tokenAmount,
-            bridgeFee: BRIDGE_FEE
+            token: address(testToken), amount: tokenAmount, bridgeFee: BRIDGE_FEE
         });
 
         deal(address(testToken), address(starkExBridge), tokenAmount);

--- a/test/unit/withdrawals/VaultWithdrawalProcessor.t.sol
+++ b/test/unit/withdrawals/VaultWithdrawalProcessor.t.sol
@@ -473,11 +473,30 @@ contract VaultWithdrawalProcessorTest is
     }
 
     function test_SetRootOverrideAllowed() public {
+        // Initial value is true, set to false
+        vm.expectEmit(true, true, true, true);
+        emit VaultWithdrawalProcessor.RootOverrideSet(true, false);
         vaultWithdrawalProcessor.setRootOverrideAllowed(false);
         assertEq(vaultWithdrawalProcessor.rootOverrideAllowed(), false, "rootOverrideAllowed should be set to false");
 
+        // Set back to true
+        vm.expectEmit(true, true, true, true);
+        emit VaultWithdrawalProcessor.RootOverrideSet(false, true);
         vaultWithdrawalProcessor.setRootOverrideAllowed(true);
         assertEq(vaultWithdrawalProcessor.rootOverrideAllowed(), true, "rootOverrideAllowed should be set to true");
+    }
+
+    function test_RevertIf_SetRootOverrideAllowed_NoChange() public {
+        // Initial value is true, trying to set to true should revert
+        vm.expectRevert(VaultWithdrawalProcessor.NoChangeInOverrideValue.selector);
+        vaultWithdrawalProcessor.setRootOverrideAllowed(true);
+
+        // Set to false first
+        vaultWithdrawalProcessor.setRootOverrideAllowed(false);
+
+        // Trying to set to false again should revert
+        vm.expectRevert(VaultWithdrawalProcessor.NoChangeInOverrideValue.selector);
+        vaultWithdrawalProcessor.setRootOverrideAllowed(false);
     }
 
     function test_RevertIf_SetRootOverrideAllowed_Unauthorized() public {

--- a/test/unit/withdrawals/VaultWithdrawalProcessor.t.sol
+++ b/test/unit/withdrawals/VaultWithdrawalProcessor.t.sol
@@ -475,13 +475,13 @@ contract VaultWithdrawalProcessorTest is
     function test_SetRootOverrideAllowed() public {
         // Initial value is true, set to false
         vm.expectEmit(true, true, true, true);
-        emit VaultWithdrawalProcessor.RootOverrideSet(true, false);
+        emit VaultWithdrawalProcessor.RootOverrideSet(false);
         vaultWithdrawalProcessor.setRootOverrideAllowed(false);
         assertEq(vaultWithdrawalProcessor.rootOverrideAllowed(), false, "rootOverrideAllowed should be set to false");
 
         // Set back to true
         vm.expectEmit(true, true, true, true);
-        emit VaultWithdrawalProcessor.RootOverrideSet(false, true);
+        emit VaultWithdrawalProcessor.RootOverrideSet(true);
         vaultWithdrawalProcessor.setRootOverrideAllowed(true);
         assertEq(vaultWithdrawalProcessor.rootOverrideAllowed(), true, "rootOverrideAllowed should be set to true");
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Tightens bridge/withdrawal safety by adding pending-withdrawal checks, safer ERC20 approvals, overflow-checked dequantization, and admin-controlled root override behavior, with updated docs and tests.
> 
> - **Withdrawals & Bridge Safety**:
>   - `LegacyStarkExchangeBridge.withdraw` now requires a nonzero pending balance before clearing/transfer (`NO_PENDING_WITHDRAWAL`).
>   - `StarkExchangeMigration` uses `SafeERC20.forceApprove` before deposits; integrates `SafeERC20` and IERC20 import; minor init decode cleanup.
> - **Vault Withdrawal Processor**:
>   - Adds `RootOverrideSet` event; new errors `NoChangeInOverrideValue` and `DequantizationOverflow`.
>   - `setRootOverrideAllowed` now rejects no-op updates and emits change event.
>   - `_transferFunds` checks for multiplication overflow before dequantizing transfer amount.
> - **Verifiers & Assets**:
>   - `AccountProofVerifier`: adds security note around commutative hash usage (no logic change).
>   - `BridgedTokenMapping`: expanded NatSpec; clarifies single-registration note.
> - **Tests**:
>   - Update unit/integration tests to expect new events/reverts and use compact struct literals; cover ETH/ERC20 migration paths and root override toggling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 779104c72230266f518154814ba63130ccc89ab3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->