### PR TITLE
Address audit feedback

### DIFF
--- a/config/devnet_config.json
+++ b/config/devnet_config.json
@@ -1,13 +1,13 @@
 {
   "allow_root_override": true,
   "vault_verifier": "0x3498311FC4D1D1AEa7c2BE9996fa9660e88B1EbE",
+  "vault_root_provider": "0xBc6E5103D599FaEC8f4D2911efAEb98814cb5Aaa",
   "operators": {
     "pauser": "0xBc6E5103D599FaEC8f4D2911efAEb98814cb5Aaa",
     "unpauser": "0xBc6E5103D599FaEC8f4D2911efAEb98814cb5Aaa",
     "disburser": "0xBc6E5103D599FaEC8f4D2911efAEb98814cb5Aaa",
     "defaultAdmin": "0xBc6E5103D599FaEC8f4D2911efAEb98814cb5Aaa",
     "accountRootManager": "0xBc6E5103D599FaEC8f4D2911efAEb98814cb5Aaa",
-    "vaultRootManager": "0xBc6E5103D599FaEC8f4D2911efAEb98814cb5Aaa",
     "tokenMappingManager": "0xBc6E5103D599FaEC8f4D2911efAEb98814cb5Aaa"
   },
   "lookup_tables": [

--- a/config/tenderly_eth_mainnet_config.json
+++ b/config/tenderly_eth_mainnet_config.json
@@ -1,13 +1,13 @@
 {
   "allow_root_override": true,
   "vault_verifier": "0x0000000000000000000000000000000000000000",
+  "vault_root_provider": "0xBc6E5103D599FaEC8f4D2911efAEb98814cb5Aaa",
   "operators": {
     "pauser": "0xBc6E5103D599FaEC8f4D2911efAEb98814cb5Aaa",
     "unpauser": "0xBc6E5103D599FaEC8f4D2911efAEb98814cb5Aaa",
     "disburser": "0xBc6E5103D599FaEC8f4D2911efAEb98814cb5Aaa",
     "defaultAdmin": "0xBc6E5103D599FaEC8f4D2911efAEb98814cb5Aaa",
     "accountRootManager": "0xBc6E5103D599FaEC8f4D2911efAEb98814cb5Aaa",
-    "vaultRootManager": "0xBc6E5103D599FaEC8f4D2911efAEb98814cb5Aaa",
     "tokenMappingManager": "0xBc6E5103D599FaEC8f4D2911efAEb98814cb5Aaa"
   },
   "lookup_tables": [

--- a/config/tenderly_zkevm_mainnet_config.json
+++ b/config/tenderly_zkevm_mainnet_config.json
@@ -1,13 +1,13 @@
 {
   "allow_root_override": true,
   "vault_verifier": "0x0000000000000000000000000000000000000000",
+  "vault_root_provider": "0xBc6E5103D599FaEC8f4D2911efAEb98814cb5Aaa",
   "operators": {
     "pauser": "0xBc6E5103D599FaEC8f4D2911efAEb98814cb5Aaa",
     "unpauser": "0xBc6E5103D599FaEC8f4D2911efAEb98814cb5Aaa",
     "disburser": "0xBc6E5103D599FaEC8f4D2911efAEb98814cb5Aaa",
     "defaultAdmin": "0xBc6E5103D599FaEC8f4D2911efAEb98814cb5Aaa",
     "accountRootManager": "0xBc6E5103D599FaEC8f4D2911efAEb98814cb5Aaa",
-    "vaultRootManager": "0xBc6E5103D599FaEC8f4D2911efAEb98814cb5Aaa",
     "tokenMappingManager": "0xBc6E5103D599FaEC8f4D2911efAEb98814cb5Aaa"
   },
   "lookup_tables": [

--- a/script/DeployL2Contracts.s.sol
+++ b/script/DeployL2Contracts.s.sol
@@ -13,6 +13,7 @@ import {ProcessorAccessControl} from "@src/withdrawals/ProcessorAccessControl.so
 contract DeployL2Contracts is Script {
     bool private allowRootOverride;
     address private vaultVerifier;
+    address private vaultRootProvider;
     address[63] private lookupTables;
     VaultWithdrawalProcessor private withdrawalProcessor;
     VaultWithdrawalProcessor.RoleOperators private operators;
@@ -23,6 +24,7 @@ contract DeployL2Contracts is Script {
         allowRootOverride = vm.parseJsonBool(config, "$.allow_root_override");
 
         vaultVerifier = vm.parseJsonAddress(config, "$.vault_verifier");
+        vaultRootProvider = vm.parseJsonAddress(config, "$.vault_root_provider");
 
         operators = abi.decode(vm.parseJson(config, "$.operators"), (ProcessorAccessControl.RoleOperators));
 
@@ -48,7 +50,8 @@ contract DeployL2Contracts is Script {
             vaultVerifier = address(new VaultEscapeProofVerifier(lookupTables));
         }
 
-        withdrawalProcessor = new VaultWithdrawalProcessor(vaultVerifier, operators, allowRootOverride);
+        withdrawalProcessor =
+            new VaultWithdrawalProcessor(vaultVerifier, vaultRootProvider, operators, allowRootOverride);
         withdrawalProcessor.registerTokenMappings(assetMappings);
 
         _logDeploymentDetails();

--- a/src/bridge/starkex/StarkExchangeMigration.sol
+++ b/src/bridge/starkex/StarkExchangeMigration.sol
@@ -34,6 +34,10 @@ contract StarkExchangeMigration is IStarkExchangeMigration, LegacyStarkExchangeB
     /// @dev Reference to native ETH, based on the value used to represent ETH on the zkEVM bridge.
     address public constant NATIVE_ETH = address(0xeee);
 
+    constructor() {
+        _disableInitializers();
+    }
+
     /**
      * @notice Initializes the contract with migration configuration
      * @param data Encoded initialization data containing addresses

--- a/src/verifiers/vaults/VaultEscapeProofVerifier.sol
+++ b/src/verifiers/vaults/VaultEscapeProofVerifier.sol
@@ -337,22 +337,11 @@ contract VaultEscapeProofVerifier is IVaultProofVerifier {
         return escapeProof[escapeProof.length - 2] >> 4;
     }
 
-    function _validateProofStructure(uint256[] calldata escapeProof) private pure returns (bool) {
-        uint256 proofLength = escapeProof.length;
-
-        // The minimal supported proof length is for a tree height of 31 in a 68 word representation as follows:
+    function _validateProofStructure(uint256[] calldata escapeProof) private pure {
+        // The only supported proof length is for a tree height of 31 in a 68 word representation as follows:
         // 1. 2 word pairs representing the vault contents + one hash of the 1st pair.
-        // 2. 31  word pairs representing the authentication path.
+        // 2. 31 word pairs representing the authentication path.
         // 3. 1 word pair representing the root and the leaf index.
-        require(proofLength >= VAULT_PROOF_LENGTH, InvalidVaultProof("Proof too short."));
-
-        // The contract supports verification paths of lengths up to 97 in a 200 word representation as described above.
-        // This limitation is imposed in order to avoid potential attacks.
-        require(proofLength < 200, InvalidVaultProof("Proof too long."));
-
-        // Ensure proofs are always a series of word pairs.
-        require((proofLength & 1) == 0, InvalidVaultProof("Proof length must be even."));
-
-        return true;
+        require(escapeProof.length == VAULT_PROOF_LENGTH, InvalidVaultProof("Invalid proof length."));
     }
 }

--- a/src/withdrawals/ProcessorAccessControl.sol
+++ b/src/withdrawals/ProcessorAccessControl.sol
@@ -17,15 +17,12 @@ abstract contract ProcessorAccessControl is AccessControlEnumerable, Pausable {
     bytes32 public constant DISBURSER_ROLE = keccak256("DISBURSER_ROLE");
     /// @notice Role for setting the account root
     bytes32 public constant ACCOUNT_ROOT_PROVIDER_ROLE = keccak256("ACCOUNT_ROOT_PROVIDER_ROLE");
-    /// @notice Role for setting the vault root
-    bytes32 public constant VAULT_ROOT_PROVIDER_ROLE = keccak256("VAULT_ROOT_PROVIDER_ROLE");
     /// @notice Role for managing token mappings
     bytes32 public constant TOKEN_MAPPING_MANAGER = keccak256("TOKEN_MAPPING_MANAGER");
 
     /// @notice Struct encapsulating addresses that can perform privileged operations
     struct RoleOperators {
         address accountRootProvider;
-        address vaultRootProvider;
         address tokenMappingManager;
         address disburser;
         address pauser;
@@ -51,7 +48,6 @@ abstract contract ProcessorAccessControl is AccessControlEnumerable, Pausable {
 
     function _validateOperators(RoleOperators memory operators) internal pure {
         require(operators.accountRootProvider != address(0), InvalidOperatorAddress());
-        require(operators.vaultRootProvider != address(0), InvalidOperatorAddress());
         require(operators.tokenMappingManager != address(0), InvalidOperatorAddress());
         require(operators.disburser != address(0), InvalidOperatorAddress());
         require(operators.pauser != address(0), InvalidOperatorAddress());
@@ -61,7 +57,6 @@ abstract contract ProcessorAccessControl is AccessControlEnumerable, Pausable {
 
     function _grantRoleOperators(RoleOperators memory operators) internal {
         _grantRole(ACCOUNT_ROOT_PROVIDER_ROLE, operators.accountRootProvider);
-        _grantRole(VAULT_ROOT_PROVIDER_ROLE, operators.vaultRootProvider);
         _grantRole(TOKEN_MAPPING_MANAGER, operators.tokenMappingManager);
         _grantRole(DISBURSER_ROLE, operators.disburser);
         _grantRole(PAUSER_ROLE, operators.pauser);

--- a/src/withdrawals/VaultWithdrawalProcessor.sol
+++ b/src/withdrawals/VaultWithdrawalProcessor.sol
@@ -43,7 +43,6 @@ contract VaultWithdrawalProcessor is
     /// @dev Upper bound for valid Stark keys (2^251 + 17 * 2^192 + 1)
     uint256 internal constant STARK_KEY_UPPER_BOUND = 0x800000000000011000000000000000000000000000000000000000000000001;
 
-    uint256 public constant VAULT_PROOF_LENGTH = 68;
     uint256 public constant ACCOUNT_PROOF_LENGTH = 27;
 
     /// @notice The vault proof verifier contract
@@ -92,11 +91,9 @@ contract VaultWithdrawalProcessor is
 
         require(receiver != address(0), ZeroAddress());
         require(accountProof.length == ACCOUNT_PROOF_LENGTH, InvalidAccountProof("Invalid account proof length"));
-        require(
-            vaultProof.length == VAULT_PROOF_LENGTH, IVaultProofVerifier.InvalidVaultProof("Invalid vault proof length")
-        );
 
         // Extract the vault and vault root information from the submitted proof
+        // Note: the verifier validates the proof length strictly (must be exactly 68)
         (IVaultProofVerifier.Vault memory vault, uint256 _vaultRoot) =
             VAULT_PROOF_VERIFIER.extractVaultAndRootFromProof(vaultProof);
 

--- a/test/integration/proofs/withdrawals/VaultWithdrawalProcessor.t.sol
+++ b/test/integration/proofs/withdrawals/VaultWithdrawalProcessor.t.sol
@@ -63,11 +63,10 @@ contract VaultWithdrawalProcessorIntegrationTest is
             disburser: address(this),
             defaultAdmin: address(this),
             accountRootProvider: address(this),
-            vaultRootProvider: address(rootReceiver),
             tokenMappingManager: address(this)
         });
 
-        vaultProcessor = new VaultWithdrawalProcessor(address(vaultVerifier), operators, true);
+        vaultProcessor = new VaultWithdrawalProcessor(address(vaultVerifier), address(rootReceiver), operators, true);
 
         vaultProcessor.setAccountRoot(accountsRoot);
         vaultProcessor.registerTokenMappings(fixAssets);

--- a/test/unit/verifiers/vaults/VaultEscapeProofVerifier.t.sol
+++ b/test/unit/verifiers/vaults/VaultEscapeProofVerifier.t.sol
@@ -68,37 +68,30 @@ contract VaultEscapeProofVerifierTest is Test, FixtureVaultEscapes, FixtureLooku
         verifier.verifyVaultProof(invalidProofBadPath);
     }
 
-    function test_RevertIf_VerifyProof_WithInvalidLength_Short() public {
-        vm.expectRevert(abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Proof too short."));
+    function test_RevertIf_VerifyProof_WithInvalidLength_TooShort() public {
+        vm.expectRevert(abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Invalid proof length."));
         verifier.verifyVaultProof(new uint256[](67));
     }
 
-    function test_RevertIf_VerifyProof_WithInvalidLength_Long() public {
-        vm.expectRevert(abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Proof too long."));
-        verifier.verifyVaultProof(new uint256[](200));
-    }
-
-    function test_RevertIf_VerifyProof_WithInvalidLength_Odd() public {
-        vm.expectRevert(
-            abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Proof length must be even.")
-        );
+    function test_RevertIf_VerifyProof_WithInvalidLength_TooLong() public {
+        vm.expectRevert(abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Invalid proof length."));
         verifier.verifyVaultProof(new uint256[](69));
     }
 
-    function test_VerifyProof_MinimumValidLength() public view {
-        // Create a proof with minimum valid length (68)
-        uint256[] memory minProof = new uint256[](68);
-        // Copy a valid proof structure
-        for (uint256 i = 0; i < 68; i++) {
-            minProof[i] = fixVaultEscapes[0].proof[i];
-        }
-        bool result = verifier.verifyVaultProof(minProof);
-        assertTrue(result, "Minimum length proof should be valid");
+    function test_RevertIf_VerifyProof_WithInvalidLength_Empty() public {
+        vm.expectRevert(abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Invalid proof length."));
+        verifier.verifyVaultProof(new uint256[](0));
     }
 
-    function test_RevertIf_VerifyProof_ExactlyAtLongLimit() public {
-        vm.expectRevert(abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Proof too long."));
-        verifier.verifyVaultProof(new uint256[](200));
+    function test_VerifyProof_ExactValidLength() public view {
+        // Create a proof with exact valid length (68)
+        uint256[] memory validLengthProof = new uint256[](68);
+        // Copy a valid proof structure
+        for (uint256 i = 0; i < 68; i++) {
+            validLengthProof[i] = fixVaultEscapes[0].proof[i];
+        }
+        bool result = verifier.verifyVaultProof(validLengthProof);
+        assertTrue(result, "Proof with exact valid length should pass");
     }
 
     function test_ExtractLeafFromProof() public view {
@@ -183,49 +176,36 @@ contract VaultEscapeProofVerifierTest is Test, FixtureVaultEscapes, FixtureLooku
     }
 
     function test_RevertIf_ExtractLeafFromInvalidProof() public {
-        vm.expectRevert(abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Proof too short."));
+        vm.expectRevert(abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Invalid proof length."));
         verifier.extractLeafFromProof(new uint256[](67));
     }
 
     function test_RevertIf_ExtractRootFromInvalidProof() public {
-        vm.expectRevert(abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Proof too short."));
+        vm.expectRevert(abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Invalid proof length."));
         verifier.extractRootFromProof(new uint256[](67));
     }
 
     function test_RevertIf_ExtractLeafAndRootFromInvalidProof() public {
-        vm.expectRevert(abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Proof too short."));
+        vm.expectRevert(abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Invalid proof length."));
         verifier.extractVaultAndRootFromProof(new uint256[](67));
     }
 
-    function test_RevertIf_ExtractFunctions_WithOddLength() public {
-        uint256[] memory oddLengthProof = new uint256[](69);
+    function test_RevertIf_ExtractFunctions_WithWrongLength() public {
+        uint256[] memory wrongLengthProof = new uint256[](69);
 
         vm.expectRevert(
-            abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Proof length must be even.")
+            abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Invalid proof length.")
         );
-        verifier.extractLeafFromProof(oddLengthProof);
+        verifier.extractLeafFromProof(wrongLengthProof);
 
         vm.expectRevert(
-            abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Proof length must be even.")
+            abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Invalid proof length.")
         );
-        verifier.extractRootFromProof(oddLengthProof);
+        verifier.extractRootFromProof(wrongLengthProof);
 
         vm.expectRevert(
-            abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Proof length must be even.")
+            abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Invalid proof length.")
         );
-        verifier.extractVaultAndRootFromProof(oddLengthProof);
-    }
-
-    function test_RevertIf_ExtractFunctions_WithLongProof() public {
-        uint256[] memory longProof = new uint256[](200);
-
-        vm.expectRevert(abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Proof too long."));
-        verifier.extractLeafFromProof(longProof);
-
-        vm.expectRevert(abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Proof too long."));
-        verifier.extractRootFromProof(longProof);
-
-        vm.expectRevert(abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Proof too long."));
-        verifier.extractVaultAndRootFromProof(longProof);
+        verifier.extractVaultAndRootFromProof(wrongLengthProof);
     }
 }

--- a/test/unit/verifiers/vaults/VaultEscapeProofVerifier.t.sol
+++ b/test/unit/verifiers/vaults/VaultEscapeProofVerifier.t.sol
@@ -193,19 +193,13 @@ contract VaultEscapeProofVerifierTest is Test, FixtureVaultEscapes, FixtureLooku
     function test_RevertIf_ExtractFunctions_WithWrongLength() public {
         uint256[] memory wrongLengthProof = new uint256[](69);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Invalid proof length.")
-        );
+        vm.expectRevert(abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Invalid proof length."));
         verifier.extractLeafFromProof(wrongLengthProof);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Invalid proof length.")
-        );
+        vm.expectRevert(abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Invalid proof length."));
         verifier.extractRootFromProof(wrongLengthProof);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Invalid proof length.")
-        );
+        vm.expectRevert(abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Invalid proof length."));
         verifier.extractVaultAndRootFromProof(wrongLengthProof);
     }
 }

--- a/test/unit/withdrawals/VaultWithdrawalProcessor.t.sol
+++ b/test/unit/withdrawals/VaultWithdrawalProcessor.t.sol
@@ -69,17 +69,13 @@ contract VaultWithdrawalProcessorTest is
         assertEq(address(vaultWithdrawalProcessor.VAULT_PROOF_VERIFIER()), address(vaultVerifier));
         assertEq(vaultWithdrawalProcessor.VAULT_ROOT_PROVIDER(), address(this));
         assertEq(vaultWithdrawalProcessor.vaultRoot(), fixVaultEscapes[0].root);
+        assertEq(vaultWithdrawalProcessor.rootOverrideAllowed(), true, "rootOverrideAllowed should be true initially");
 
         for (uint256 i = 0; i < fixAssets.length; i++) {
             uint256 id = fixAssets[i].tokenOnIMX.id;
             assertEq(vaultWithdrawalProcessor.getZKEVMAddress(id), fixAssets[i].tokenOnZKEVM);
             assertEq(vaultWithdrawalProcessor.getTokenMapping(id).tokenOnIMX.quantum, fixAssets[i].tokenOnIMX.quantum);
         }
-    }
-
-    function test_Constants() public view {
-        assertEq(vaultWithdrawalProcessor.VAULT_PROOF_LENGTH(), 68, "VAULT_PROOF_LENGTH should be 68");
-        assertEq(vaultWithdrawalProcessor.rootOverrideAllowed(), true, "rootOverrideAllowed should be true initially");
     }
 
     function test_Constructor_RootOverrideAllowed() public {
@@ -240,7 +236,7 @@ contract VaultWithdrawalProcessorTest is
         uint256[] memory emptyProof = new uint256[](0);
 
         vm.expectRevert(
-            abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Invalid vault proof length")
+            abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Invalid proof length.")
         );
         vaultWithdrawalProcessor.verifyAndProcessWithdrawal(recipient, sampleAccount.proof, emptyProof);
     }
@@ -253,7 +249,7 @@ contract VaultWithdrawalProcessorTest is
         }
 
         vm.expectRevert(
-            abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Invalid vault proof length")
+            abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Invalid proof length.")
         );
         vaultWithdrawalProcessor.verifyAndProcessWithdrawal(recipient, sampleAccount.proof, wrongLengthProof);
     }

--- a/test/unit/withdrawals/VaultWithdrawalProcessor.t.sol
+++ b/test/unit/withdrawals/VaultWithdrawalProcessor.t.sol
@@ -42,7 +42,6 @@ contract VaultWithdrawalProcessorTest is
         unpauser: address(this),
         disburser: address(this),
         defaultAdmin: address(this),
-        vaultRootProvider: address(this),
         accountRootProvider: address(this),
         tokenMappingManager: address(this)
     });
@@ -58,7 +57,7 @@ contract VaultWithdrawalProcessorTest is
 
         vaultVerifier = new MockVaultVerifier(ZKEVM_MAINNET_LOOKUP_TABLES);
 
-        vaultWithdrawalProcessor = new VaultWithdrawalProcessor(address(vaultVerifier), initRoles, true);
+        vaultWithdrawalProcessor = new VaultWithdrawalProcessor(address(vaultVerifier), address(this), initRoles, true);
         vaultWithdrawalProcessor.setVaultRoot(fixVaultEscapes[0].root);
         vaultWithdrawalProcessor.setAccountRoot(accountsRoot);
         vaultWithdrawalProcessor.registerTokenMappings(fixAssets);
@@ -68,6 +67,7 @@ contract VaultWithdrawalProcessorTest is
 
     function test_Constructor() public view {
         assertEq(address(vaultWithdrawalProcessor.VAULT_PROOF_VERIFIER()), address(vaultVerifier));
+        assertEq(vaultWithdrawalProcessor.VAULT_ROOT_PROVIDER(), address(this));
         assertEq(vaultWithdrawalProcessor.vaultRoot(), fixVaultEscapes[0].root);
 
         for (uint256 i = 0; i < fixAssets.length; i++) {
@@ -85,7 +85,7 @@ contract VaultWithdrawalProcessorTest is
     function test_Constructor_RootOverrideAllowed() public {
         // Test with rootOverrideAllowed = false
         VaultWithdrawalProcessor processorWithOverrideDisabled =
-            new VaultWithdrawalProcessor(address(vaultVerifier), initRoles, false);
+            new VaultWithdrawalProcessor(address(vaultVerifier), address(this), initRoles, false);
         assertEq(
             processorWithOverrideDisabled.rootOverrideAllowed(),
             false,
@@ -321,7 +321,12 @@ contract VaultWithdrawalProcessorTest is
 
     function test_RevertIf_Constructor_ZeroVaultVerifier() public {
         vm.expectRevert(BaseVaultWithdrawalProcessor.ZeroAddress.selector);
-        new VaultWithdrawalProcessor(address(0), initRoles, true);
+        new VaultWithdrawalProcessor(address(0), address(this), initRoles, true);
+    }
+
+    function test_RevertIf_Constructor_ZeroVaultRootProvider() public {
+        vm.expectRevert(BaseVaultWithdrawalProcessor.ZeroAddress.selector);
+        new VaultWithdrawalProcessor(address(vaultVerifier), address(0), initRoles, true);
     }
 
     function test_RevertIf_Constructor_InvalidPauserOperator() public {
@@ -330,13 +335,12 @@ contract VaultWithdrawalProcessorTest is
             unpauser: address(this),
             disburser: address(this),
             defaultAdmin: address(this),
-            vaultRootProvider: address(this),
             accountRootProvider: address(this),
             tokenMappingManager: address(this)
         });
 
         vm.expectRevert(ProcessorAccessControl.InvalidOperatorAddress.selector);
-        new VaultWithdrawalProcessor(address(vaultVerifier), invalidRoles, true);
+        new VaultWithdrawalProcessor(address(vaultVerifier), address(this), invalidRoles, true);
     }
 
     function test_RevertIf_Constructor_InvalidUnpauserOperator() public {
@@ -345,13 +349,12 @@ contract VaultWithdrawalProcessorTest is
             unpauser: address(0), // Invalid: zero address
             disburser: address(this),
             defaultAdmin: address(this),
-            vaultRootProvider: address(this),
             accountRootProvider: address(this),
             tokenMappingManager: address(this)
         });
 
         vm.expectRevert(ProcessorAccessControl.InvalidOperatorAddress.selector);
-        new VaultWithdrawalProcessor(address(vaultVerifier), invalidRoles, true);
+        new VaultWithdrawalProcessor(address(vaultVerifier), address(this), invalidRoles, true);
     }
 
     function test_RevertIf_Constructor_InvalidDisburserOperator() public {
@@ -360,13 +363,12 @@ contract VaultWithdrawalProcessorTest is
             unpauser: address(this),
             disburser: address(0), // Invalid: zero address
             defaultAdmin: address(this),
-            vaultRootProvider: address(this),
             accountRootProvider: address(this),
             tokenMappingManager: address(this)
         });
 
         vm.expectRevert(ProcessorAccessControl.InvalidOperatorAddress.selector);
-        new VaultWithdrawalProcessor(address(vaultVerifier), invalidRoles, true);
+        new VaultWithdrawalProcessor(address(vaultVerifier), address(this), invalidRoles, true);
     }
 
     function test_RevertIf_Constructor_InvalidDefaultAdminOperator() public {
@@ -375,28 +377,12 @@ contract VaultWithdrawalProcessorTest is
             unpauser: address(this),
             disburser: address(this),
             defaultAdmin: address(0), // Invalid: zero address
-            vaultRootProvider: address(this),
             accountRootProvider: address(this),
             tokenMappingManager: address(this)
         });
 
         vm.expectRevert(ProcessorAccessControl.InvalidOperatorAddress.selector);
-        new VaultWithdrawalProcessor(address(vaultVerifier), invalidRoles, true);
-    }
-
-    function test_RevertIf_Constructor_InvalidVaultRootProviderOperator() public {
-        ProcessorAccessControl.RoleOperators memory invalidRoles = ProcessorAccessControl.RoleOperators({
-            pauser: address(this),
-            unpauser: address(this),
-            disburser: address(this),
-            defaultAdmin: address(this),
-            vaultRootProvider: address(0), // Invalid: zero address
-            accountRootProvider: address(this),
-            tokenMappingManager: address(this)
-        });
-
-        vm.expectRevert(ProcessorAccessControl.InvalidOperatorAddress.selector);
-        new VaultWithdrawalProcessor(address(vaultVerifier), invalidRoles, true);
+        new VaultWithdrawalProcessor(address(vaultVerifier), address(this), invalidRoles, true);
     }
 
     function test_RevertIf_Constructor_InvalidAccountRootProviderOperator() public {
@@ -405,13 +391,12 @@ contract VaultWithdrawalProcessorTest is
             unpauser: address(this),
             disburser: address(this),
             defaultAdmin: address(this),
-            vaultRootProvider: address(this),
             accountRootProvider: address(0), // Invalid: zero address
             tokenMappingManager: address(this)
         });
 
         vm.expectRevert(ProcessorAccessControl.InvalidOperatorAddress.selector);
-        new VaultWithdrawalProcessor(address(vaultVerifier), invalidRoles, true);
+        new VaultWithdrawalProcessor(address(vaultVerifier), address(this), invalidRoles, true);
     }
 
     function test_RevertIf_Constructor_InvalidTokenMappingManagerOperator() public {
@@ -420,13 +405,12 @@ contract VaultWithdrawalProcessorTest is
             unpauser: address(this),
             disburser: address(this),
             defaultAdmin: address(this),
-            vaultRootProvider: address(this),
             accountRootProvider: address(this),
             tokenMappingManager: address(0) // Invalid: zero address
         });
 
         vm.expectRevert(ProcessorAccessControl.InvalidOperatorAddress.selector);
-        new VaultWithdrawalProcessor(address(vaultVerifier), invalidRoles, true);
+        new VaultWithdrawalProcessor(address(vaultVerifier), address(this), invalidRoles, true);
     }
 
     function test_SetVaultRoot() public view {
@@ -436,13 +420,7 @@ contract VaultWithdrawalProcessorTest is
     function test_RevertIf_SetVaultRoot_Unauthorized() public {
         uint256 newRoot = 0x123;
         vm.startPrank(address(0x123));
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IAccessControl.AccessControlUnauthorizedAccount.selector,
-                address(0x123),
-                vaultWithdrawalProcessor.VAULT_ROOT_PROVIDER_ROLE()
-            )
-        );
+        vm.expectRevert(VaultWithdrawalProcessor.UnauthorizedVaultRootProvider.selector);
         vaultWithdrawalProcessor.setVaultRoot(newRoot);
     }
 
@@ -536,7 +514,8 @@ contract VaultWithdrawalProcessorTest is
 
     function test_RevertIf_VaultRootNotSet() public {
         // Create a new processor without setting vault root
-        VaultWithdrawalProcessor newProcessor = new VaultWithdrawalProcessor(address(vaultVerifier), initRoles, true);
+        VaultWithdrawalProcessor newProcessor =
+            new VaultWithdrawalProcessor(address(vaultVerifier), address(this), initRoles, true);
         newProcessor.setAccountRoot(accountsRoot);
         newProcessor.registerTokenMappings(fixAssets);
 
@@ -549,7 +528,8 @@ contract VaultWithdrawalProcessorTest is
 
     function test_RevertIf_AccountRootNotSet() public {
         // Create a new processor without setting account root
-        VaultWithdrawalProcessor newProcessor = new VaultWithdrawalProcessor(address(vaultVerifier), initRoles, true);
+        VaultWithdrawalProcessor newProcessor =
+            new VaultWithdrawalProcessor(address(vaultVerifier), address(this), initRoles, true);
         newProcessor.setVaultRoot(fixVaultEscapes[0].root);
         newProcessor.registerTokenMappings(fixAssets);
 

--- a/test/unit/withdrawals/VaultWithdrawalProcessor.t.sol
+++ b/test/unit/withdrawals/VaultWithdrawalProcessor.t.sol
@@ -235,9 +235,7 @@ contract VaultWithdrawalProcessorTest is
     function test_RevertIf_EmptyVaultProof() public {
         uint256[] memory emptyProof = new uint256[](0);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Invalid proof length.")
-        );
+        vm.expectRevert(abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Invalid proof length."));
         vaultWithdrawalProcessor.verifyAndProcessWithdrawal(recipient, sampleAccount.proof, emptyProof);
     }
 
@@ -248,9 +246,7 @@ contract VaultWithdrawalProcessorTest is
             wrongLengthProof[i] = i;
         }
 
-        vm.expectRevert(
-            abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Invalid proof length.")
-        );
+        vm.expectRevert(abi.encodeWithSelector(IVaultProofVerifier.InvalidVaultProof.selector, "Invalid proof length."));
         vaultWithdrawalProcessor.verifyAndProcessWithdrawal(recipient, sampleAccount.proof, wrongLengthProof);
     }
 


### PR DESCRIPTION
This PR addresses feedback from the external audit, documented [here](https://hackmd.io/vMV6PXV4SvKRpsERtbRx1A).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect core withdrawal authorization (who can set the vault root) and proof validation strictness; misconfiguration of the new `vault_root_provider` address or unexpected proof formats could block withdrawals.
> 
> **Overview**
> **Vault root setting is tightened and re-wired.** `VaultWithdrawalProcessor` now takes an immutable `VAULT_ROOT_PROVIDER` address in the constructor (wired from new `vault_root_provider` config + deploy script) and `setVaultRoot` no longer uses an AccessControl role; it instead enforces `msg.sender == VAULT_ROOT_PROVIDER` with a dedicated `UnauthorizedVaultRootProvider` error.
> 
> **Proof validation is made stricter.** `VaultEscapeProofVerifier` now only accepts proofs of exactly length 68 (single supported format) and the processor relies on the verifier for length checks; unit tests are updated to match the new revert reasons.
> 
> **Proxy/upgrade safety improvement.** `StarkExchangeMigration` now disables initializers in the implementation constructor, and tests are updated to deploy it behind an `ERC1967Proxy` and assert initialization behavior accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 358732189061b4887feafb7c99c161a1bce3ff95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->