### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# Global owner
+@immutable/rollups
+
+# Github actions
+.github @immutable/rollups  @immutable/security

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Global owner
-@immutable/rollups
+* @immutable/rollups
 
 # Github actions
 .github @immutable/rollups  @immutable/security


### PR DESCRIPTION
Add CODEOWNERS file. The file makes the rollups team responsible for the repo in general and the rollups and the security teams responsible for the github actions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Repo metadata-only change that affects review routing/approvals but does not change runtime code or behavior.
> 
> **Overview**
> Adds a `CODEOWNERS` file to enforce default review ownership by `@immutable/rollups` for the entire repo.
> 
> Sets shared ownership for `.github` (GitHub Actions/workflows) between `@immutable/rollups` and `@immutable/security`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4c5fe5489a8a72ebeabce568eef70ada42f9eba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->