### PR TITLE
Add StarkExchangeMigrationV2 to Ethereum deployment script

### DIFF
--- a/config/deploy/mainnet/eth_config_input.json
+++ b/config/deploy/mainnet/eth_config_input.json
@@ -8,6 +8,7 @@
     "axelar_gateway": "0x4F4495243837681061C4743b74B3eEdf548D56A5"
   },
   "stark_exchange_migration": {
-    "implementation_address": "0x0000000000000000000000000000000000000000"
+    "implementation_address": "0x0000000000000000000000000000000000000000",
+    "v2_implementation_address": "0x0000000000000000000000000000000000000000"
   }
 }

--- a/config/deploy/mainnet/eth_config_input.json
+++ b/config/deploy/mainnet/eth_config_input.json
@@ -8,7 +8,7 @@
     "axelar_gateway": "0x4F4495243837681061C4743b74B3eEdf548D56A5"
   },
   "stark_exchange_migration": {
-    "implementation_address": "0x0000000000000000000000000000000000000000",
+    "implementation_address": "0x58b5484F489f7858DC83a5a677338074b57de806",
     "v2_implementation_address": "0x0000000000000000000000000000000000000000"
   }
 }

--- a/config/deploy/mainnet/eth_config_input.json
+++ b/config/deploy/mainnet/eth_config_input.json
@@ -8,7 +8,7 @@
     "axelar_gateway": "0x4F4495243837681061C4743b74B3eEdf548D56A5"
   },
   "stark_exchange_migration": {
-    "implementation_address": "0x58b5484F489f7858DC83a5a677338074b57de806",
-    "v2_implementation_address": "0x0000000000000000000000000000000000000000"
+    "version": 2,
+    "implementation_address": "0x0000000000000000000000000000000000000000"
   }
 }

--- a/config/deploy/mainnet/eth_deployed.json
+++ b/config/deploy/mainnet/eth_deployed.json
@@ -8,6 +8,7 @@
     "axelar_gateway": "0x4F4495243837681061C4743b74B3eEdf548D56A5"
   },
   "stark_exchange_migration": {
-    "implementation_address": "0x58b5484F489f7858DC83a5a677338074b57de806"
+    "implementation_address": "0x58b5484F489f7858DC83a5a677338074b57de806",
+    "v2_implementation_address": "0x0000000000000000000000000000000000000000"
   }
 }

--- a/config/deploy/mainnet/eth_deployed.json
+++ b/config/deploy/mainnet/eth_deployed.json
@@ -8,7 +8,7 @@
     "axelar_gateway": "0x4F4495243837681061C4743b74B3eEdf548D56A5"
   },
   "stark_exchange_migration": {
-    "implementation_address": "0x58b5484F489f7858DC83a5a677338074b57de806",
-    "v2_implementation_address": "0x0000000000000000000000000000000000000000"
+    "version": 1,
+    "implementation_address": "0x58b5484F489f7858DC83a5a677338074b57de806"
   }
 }

--- a/config/deploy/sandbox/eth_config_input.json
+++ b/config/deploy/sandbox/eth_config_input.json
@@ -8,7 +8,7 @@
     "axelar_gateway": "0xe432150cce91c13a887f7D836923d5597adD8E31"
   },
   "stark_exchange_migration": {
-    "implementation_address": "0x0000000000000000000000000000000000000000",
+    "implementation_address": "0x9F9b4A495A62191A4225759Ae7C00906Cc6417B8",
     "v2_implementation_address": "0x0000000000000000000000000000000000000000"
   }
 }

--- a/config/deploy/sandbox/eth_config_input.json
+++ b/config/deploy/sandbox/eth_config_input.json
@@ -8,7 +8,7 @@
     "axelar_gateway": "0xe432150cce91c13a887f7D836923d5597adD8E31"
   },
   "stark_exchange_migration": {
-    "implementation_address": "0x9F9b4A495A62191A4225759Ae7C00906Cc6417B8",
-    "v2_implementation_address": "0x0000000000000000000000000000000000000000"
+    "version": 2,
+    "implementation_address": "0x0000000000000000000000000000000000000000"
   }
 }

--- a/config/deploy/sandbox/eth_config_input.json
+++ b/config/deploy/sandbox/eth_config_input.json
@@ -8,6 +8,7 @@
     "axelar_gateway": "0xe432150cce91c13a887f7D836923d5597adD8E31"
   },
   "stark_exchange_migration": {
-    "implementation_address": "0x0000000000000000000000000000000000000000"
+    "implementation_address": "0x0000000000000000000000000000000000000000",
+    "v2_implementation_address": "0x0000000000000000000000000000000000000000"
   }
 }

--- a/config/deploy/sandbox/eth_deployed.json
+++ b/config/deploy/sandbox/eth_deployed.json
@@ -8,6 +8,7 @@
     "axelar_gateway": "0xe432150cce91c13a887f7D836923d5597adD8E31"
   },
   "stark_exchange_migration": {
-    "implementation_address": "0x9F9b4A495A62191A4225759Ae7C00906Cc6417B8"
+    "implementation_address": "0x9F9b4A495A62191A4225759Ae7C00906Cc6417B8",
+    "v2_implementation_address": "0x0000000000000000000000000000000000000000"
   }
 }

--- a/config/deploy/sandbox/eth_deployed.json
+++ b/config/deploy/sandbox/eth_deployed.json
@@ -8,7 +8,7 @@
     "axelar_gateway": "0xe432150cce91c13a887f7D836923d5597adD8E31"
   },
   "stark_exchange_migration": {
-    "implementation_address": "0x9F9b4A495A62191A4225759Ae7C00906Cc6417B8",
-    "v2_implementation_address": "0x0000000000000000000000000000000000000000"
+    "version": 1,
+    "implementation_address": "0x9F9b4A495A62191A4225759Ae7C00906Cc6417B8"
   }
 }

--- a/script/DeployEthContracts.s.sol
+++ b/script/DeployEthContracts.s.sol
@@ -90,6 +90,7 @@ contract DeployEthContracts is Script {
         //    The version is selected via stark_exchange_migration.version in the config.
         //    The constructor only calls _disableInitializers(). No proxy is deployed here.
         //    The existing StarkEx bridge proxy will be upgraded separately via governance.
+        require(migrationVersion == 1 || migrationVersion == 2, "stark_exchange_migration.version must be 1 or 2");
         if (migrationImpl == address(0)) {
             if (migrationVersion == 1) {
                 migrationImpl = address(new StarkExchangeMigration());
@@ -121,8 +122,7 @@ contract DeployEthContracts is Script {
             require(axelarGateway != address(0), "vault_root_sender_adapter.axelar_gateway is zero address");
         }
 
-        // StarkExchangeMigration: validate version selector
-        require(migrationVersion == 1 || migrationVersion == 2, "stark_exchange_migration.version must be 1 or 2");
+        // StarkExchangeMigration: no constructor params to validate (only calls _disableInitializers)
     }
 
     /**

--- a/script/DeployEthContracts.s.sol
+++ b/script/DeployEthContracts.s.sol
@@ -6,12 +6,14 @@ import "forge-std/Script.sol";
 import "forge-std/console.sol";
 import {VaultRootSenderAdapter} from "../src/bridge/messaging/VaultRootSenderAdapter.sol";
 import {StarkExchangeMigration} from "../src/bridge/starkex/StarkExchangeMigration.sol";
+import {StarkExchangeMigrationV2} from "../src/bridge/starkex/StarkExchangeMigrationV2.sol";
 
 /**
  * @title DeployEthContracts
  * @notice Deploys the migration contracts on Ethereum:
  *         1. VaultRootSenderAdapter
  *         2. StarkExchangeMigration (implementation only, no proxy)
+ *         3. StarkExchangeMigrationV2 (implementation only, no proxy)
  *
  * @dev The StarkExchangeMigration is deployed as an implementation contract only.
  *      The existing StarkEx bridge proxy on-chain will be upgraded to point to this
@@ -39,6 +41,9 @@ contract DeployEthContracts is Script {
     // StarkExchangeMigration
     address private migrationImpl;
 
+    // StarkExchangeMigrationV2
+    address private migrationV2Impl;
+
     string private configFilePath;
     string private outputFilePath;
 
@@ -62,6 +67,9 @@ contract DeployEthContracts is Script {
 
         // --- StarkExchangeMigration ---
         migrationImpl = vm.parseJsonAddress(config, "$.stark_exchange_migration.implementation_address");
+
+        // --- StarkExchangeMigrationV2 ---
+        migrationV2Impl = vm.parseJsonAddress(config, "$.stark_exchange_migration.v2_implementation_address");
     }
 
     /// @notice Deploys the Ethereum contracts.
@@ -91,6 +99,16 @@ contract DeployEthContracts is Script {
             console.log("Deployed StarkExchangeMigration implementation:", migrationImpl);
         } else {
             console.log("Using existing StarkExchangeMigration implementation:", migrationImpl);
+        }
+
+        // 3. Deploy StarkExchangeMigrationV2 implementation (if not already deployed)
+        //    The constructor only calls _disableInitializers(). No proxy is deployed here.
+        //    The existing StarkEx bridge proxy will be upgraded separately via governance.
+        if (migrationV2Impl == address(0)) {
+            migrationV2Impl = address(new StarkExchangeMigrationV2());
+            console.log("Deployed StarkExchangeMigrationV2 implementation:", migrationV2Impl);
+        } else {
+            console.log("Using existing StarkExchangeMigrationV2 implementation:", migrationV2Impl);
         }
 
         vm.stopBroadcast();
@@ -126,6 +144,7 @@ contract DeployEthContracts is Script {
 
         vm.writeJson(vm.toString(senderAdapter), outputFilePath, ".vault_root_sender_adapter.address");
         vm.writeJson(vm.toString(migrationImpl), outputFilePath, ".stark_exchange_migration.implementation_address");
+        vm.writeJson(vm.toString(migrationV2Impl), outputFilePath, ".stark_exchange_migration.v2_implementation_address");
 
         console.log("Deployment output written to:", outputFilePath);
     }
@@ -134,5 +153,6 @@ contract DeployEthContracts is Script {
         console.log("--- Ethereum Deployment Summary ---");
         console.log("VaultRootSenderAdapter:", senderAdapter);
         console.log("StarkExchangeMigration (impl):", migrationImpl);
+        console.log("StarkExchangeMigrationV2 (impl):", migrationV2Impl);
     }
 }

--- a/script/DeployEthContracts.s.sol
+++ b/script/DeployEthContracts.s.sol
@@ -144,7 +144,9 @@ contract DeployEthContracts is Script {
 
         vm.writeJson(vm.toString(senderAdapter), outputFilePath, ".vault_root_sender_adapter.address");
         vm.writeJson(vm.toString(migrationImpl), outputFilePath, ".stark_exchange_migration.implementation_address");
-        vm.writeJson(vm.toString(migrationV2Impl), outputFilePath, ".stark_exchange_migration.v2_implementation_address");
+        vm.writeJson(
+            vm.toString(migrationV2Impl), outputFilePath, ".stark_exchange_migration.v2_implementation_address"
+        );
 
         console.log("Deployment output written to:", outputFilePath);
     }

--- a/script/DeployEthContracts.s.sol
+++ b/script/DeployEthContracts.s.sol
@@ -12,8 +12,7 @@ import {StarkExchangeMigrationV2} from "../src/bridge/starkex/StarkExchangeMigra
  * @title DeployEthContracts
  * @notice Deploys the migration contracts on Ethereum:
  *         1. VaultRootSenderAdapter
- *         2. StarkExchangeMigration (implementation only, no proxy)
- *         3. StarkExchangeMigrationV2 (implementation only, no proxy)
+ *         2. StarkExchangeMigration implementation (version selected via config)
  *
  * @dev The StarkExchangeMigration is deployed as an implementation contract only.
  *      The existing StarkEx bridge proxy on-chain will be upgraded to point to this
@@ -38,11 +37,9 @@ contract DeployEthContracts is Script {
     address private axelarGasService;
     address private axelarGateway;
 
-    // StarkExchangeMigration
+    // StarkExchangeMigration implementation (version 1 or 2, selected via config)
     address private migrationImpl;
-
-    // StarkExchangeMigrationV2
-    address private migrationV2Impl;
+    uint256 private migrationVersion;
 
     string private configFilePath;
     string private outputFilePath;
@@ -67,9 +64,7 @@ contract DeployEthContracts is Script {
 
         // --- StarkExchangeMigration ---
         migrationImpl = vm.parseJsonAddress(config, "$.stark_exchange_migration.implementation_address");
-
-        // --- StarkExchangeMigrationV2 ---
-        migrationV2Impl = vm.parseJsonAddress(config, "$.stark_exchange_migration.v2_implementation_address");
+        migrationVersion = vm.parseJsonUint(config, "$.stark_exchange_migration.version");
     }
 
     /// @notice Deploys the Ethereum contracts.
@@ -91,24 +86,19 @@ contract DeployEthContracts is Script {
             console.log("Using existing VaultRootSenderAdapter:", senderAdapter);
         }
 
-        // 2. Deploy StarkExchangeMigration implementation (if not already deployed)
+        // 2. Deploy StarkExchangeMigration implementation (if not already deployed).
+        //    The version is selected via stark_exchange_migration.version in the config.
         //    The constructor only calls _disableInitializers(). No proxy is deployed here.
         //    The existing StarkEx bridge proxy will be upgraded separately via governance.
         if (migrationImpl == address(0)) {
-            migrationImpl = address(new StarkExchangeMigration());
-            console.log("Deployed StarkExchangeMigration implementation:", migrationImpl);
+            if (migrationVersion == 1) {
+                migrationImpl = address(new StarkExchangeMigration());
+            } else {
+                migrationImpl = address(new StarkExchangeMigrationV2());
+            }
+            console.log("Deployed StarkExchangeMigration v%d implementation:", migrationVersion, migrationImpl);
         } else {
-            console.log("Using existing StarkExchangeMigration implementation:", migrationImpl);
-        }
-
-        // 3. Deploy StarkExchangeMigrationV2 implementation (if not already deployed)
-        //    The constructor only calls _disableInitializers(). No proxy is deployed here.
-        //    The existing StarkEx bridge proxy will be upgraded separately via governance.
-        if (migrationV2Impl == address(0)) {
-            migrationV2Impl = address(new StarkExchangeMigrationV2());
-            console.log("Deployed StarkExchangeMigrationV2 implementation:", migrationV2Impl);
-        } else {
-            console.log("Using existing StarkExchangeMigrationV2 implementation:", migrationV2Impl);
+            console.log("Using existing StarkExchangeMigration v%d implementation:", migrationVersion, migrationImpl);
         }
 
         vm.stopBroadcast();
@@ -131,7 +121,8 @@ contract DeployEthContracts is Script {
             require(axelarGateway != address(0), "vault_root_sender_adapter.axelar_gateway is zero address");
         }
 
-        // StarkExchangeMigration: no constructor params to validate (only calls _disableInitializers)
+        // StarkExchangeMigration: validate version selector
+        require(migrationVersion == 1 || migrationVersion == 2, "stark_exchange_migration.version must be 1 or 2");
     }
 
     /**
@@ -144,9 +135,6 @@ contract DeployEthContracts is Script {
 
         vm.writeJson(vm.toString(senderAdapter), outputFilePath, ".vault_root_sender_adapter.address");
         vm.writeJson(vm.toString(migrationImpl), outputFilePath, ".stark_exchange_migration.implementation_address");
-        vm.writeJson(
-            vm.toString(migrationV2Impl), outputFilePath, ".stark_exchange_migration.v2_implementation_address"
-        );
 
         console.log("Deployment output written to:", outputFilePath);
     }
@@ -154,7 +142,6 @@ contract DeployEthContracts is Script {
     function _logSummary() private view {
         console.log("--- Ethereum Deployment Summary ---");
         console.log("VaultRootSenderAdapter:", senderAdapter);
-        console.log("StarkExchangeMigration (impl):", migrationImpl);
-        console.log("StarkExchangeMigrationV2 (impl):", migrationV2Impl);
+        console.log("StarkExchangeMigration v%d (impl):", migrationVersion, migrationImpl);
     }
 }

--- a/script/README.md
+++ b/script/README.md
@@ -7,7 +7,7 @@ Solidity scripts for deploying and configuring the migration contracts using Fou
 | Script | Chain | Purpose | Executed By |
 |--------|-------|---------|-------------|
 | `DeployZkEVMContracts.s.sol` | zkEVM | Deploy VaultEscapeProofVerifier, VaultRootReceiverAdapter, VaultWithdrawalProcessor | Deployer |
-| `DeployEthContracts.s.sol` | Ethereum | Deploy VaultRootSenderAdapter, StarkExchangeMigration, and StarkExchangeMigrationV2 implementations | Deployer |
+| `DeployEthContracts.s.sol` | Ethereum | Deploy VaultRootSenderAdapter and StarkExchangeMigration implementation (version selected via config) | Deployer |
 | `GenerateAssetMappings.s.sol` | - | Generate asset mappings by querying bridge contract | Utility (offline) |
 | `VerifyAssetMappings.s.sol` | - | Verify asset mappings against bridge contract | Utility (read-only) |
 | `RegisterTokenMappings.s.sol` | zkEVM | Register token mappings on the processor | TOKEN_MAPPING_MANAGER |
@@ -88,9 +88,8 @@ forge script script/DeployEthContracts.s.sol \
 **Output:** Creates `config/eth_deployed.json` with deployed addresses populated in:
 - `vault_root_sender_adapter.address`
 - `stark_exchange_migration.implementation_address`
-- `stark_exchange_migration.v2_implementation_address`
 
-**Note:** Both `StarkExchangeMigration` and `StarkExchangeMigrationV2` are deployed as implementations only (no proxy). The existing StarkEx bridge proxy on-chain must be upgraded to point to an implementation separately (e.g., via governance), at which point `initialize` is called with the appropriate parameters.
+**Note:** The `StarkExchangeMigration` is deployed as an implementation only (no proxy). The existing StarkEx bridge proxy on-chain must be upgraded to point to this implementation separately (e.g., via governance), at which point `initialize` is called with the appropriate parameters. Set `stark_exchange_migration.version` to `1` for `StarkExchangeMigration` or `2` for `StarkExchangeMigrationV2`.
 
 ### Step 4: Generate Asset Mappings (zkEVM)
 
@@ -192,8 +191,8 @@ Deploys the Ethereum contracts for the migration system.
     "axelar_gateway": "0x..."
   },
   "stark_exchange_migration": {
-    "implementation_address": "0x0000...",
-    "v2_implementation_address": "0x0000..."
+    "version": 2,
+    "implementation_address": "0x0000..."
   }
 }
 ```

--- a/script/README.md
+++ b/script/README.md
@@ -7,7 +7,7 @@ Solidity scripts for deploying and configuring the migration contracts using Fou
 | Script | Chain | Purpose | Executed By |
 |--------|-------|---------|-------------|
 | `DeployZkEVMContracts.s.sol` | zkEVM | Deploy VaultEscapeProofVerifier, VaultRootReceiverAdapter, VaultWithdrawalProcessor | Deployer |
-| `DeployEthContracts.s.sol` | Ethereum | Deploy VaultRootSenderAdapter and StarkExchangeMigration implementation | Deployer |
+| `DeployEthContracts.s.sol` | Ethereum | Deploy VaultRootSenderAdapter, StarkExchangeMigration, and StarkExchangeMigrationV2 implementations | Deployer |
 | `GenerateAssetMappings.s.sol` | - | Generate asset mappings by querying bridge contract | Utility (offline) |
 | `VerifyAssetMappings.s.sol` | - | Verify asset mappings against bridge contract | Utility (read-only) |
 | `RegisterTokenMappings.s.sol` | zkEVM | Register token mappings on the processor | TOKEN_MAPPING_MANAGER |
@@ -88,8 +88,9 @@ forge script script/DeployEthContracts.s.sol \
 **Output:** Creates `config/eth_deployed.json` with deployed addresses populated in:
 - `vault_root_sender_adapter.address`
 - `stark_exchange_migration.implementation_address`
+- `stark_exchange_migration.v2_implementation_address`
 
-**Note:** The `StarkExchangeMigration` is deployed as an implementation only. The existing StarkEx bridge proxy on-chain must be upgraded to point to this implementation separately (e.g., via governance), at which point `initialize` is called with the migration parameters.
+**Note:** Both `StarkExchangeMigration` and `StarkExchangeMigrationV2` are deployed as implementations only (no proxy). The existing StarkEx bridge proxy on-chain must be upgraded to point to an implementation separately (e.g., via governance), at which point `initialize` is called with the appropriate parameters.
 
 ### Step 4: Generate Asset Mappings (zkEVM)
 
@@ -191,7 +192,8 @@ Deploys the Ethereum contracts for the migration system.
     "axelar_gateway": "0x..."
   },
   "stark_exchange_migration": {
-    "implementation_address": "0x0000..."
+    "implementation_address": "0x0000...",
+    "v2_implementation_address": "0x0000..."
   }
 }
 ```


### PR DESCRIPTION
## Summary

- Extends `DeployEthContracts.s.sol` to deploy `StarkExchangeMigrationV2` as a third implementation contract (step 3), following the same idempotent pattern as V1
- Adds `v2_implementation_address` field to `stark_exchange_migration` in all four eth config files (mainnet + sandbox, input + deployed), defaulting to the zero address
- Updates `script/README.md` to reflect V2 in the scripts table, config structure, and output field list

## Test plan

- [ ] Run `DeployEthContracts.s.sol` in simulation mode against sandbox (no `--broadcast`) and confirm V2 implementation address is printed and written to output
- [ ] Run with `--broadcast` against sandbox and confirm V2 is deployed; update `sandbox/eth_deployed.json` with the real address
- [ ] Confirm re-running with the deployed address set skips deployment ("Using existing" log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the Ethereum deployment flow to select between two migration implementations and introduces a new config field that, if mis-set, could deploy or reference the wrong on-chain implementation for a proxy upgrade.
> 
> **Overview**
> **Adds versioned deployment support for `StarkExchangeMigration` on Ethereum.** `DeployEthContracts.s.sol` now reads `stark_exchange_migration.version`, validates it is `1` or `2`, and deploys either `StarkExchangeMigration` or `StarkExchangeMigrationV2`, with updated logging.
> 
> **Updates deployment configs/docs accordingly.** Mainnet and sandbox `eth_config_input.json`/`eth_deployed.json` gain a `stark_exchange_migration.version` field, and `script/README.md` documents the new version selection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90ee64e8cfdb01acf9297c18ae253f9888c006f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->