### PR TITLE
Record mainnet StarkExchangeMigrationV2 deployment

### DIFF
--- a/config/deploy/mainnet/eth_config_input.json
+++ b/config/deploy/mainnet/eth_config_input.json
@@ -9,6 +9,6 @@
   },
   "stark_exchange_migration": {
     "version": 2,
-    "implementation_address": "0x0000000000000000000000000000000000000000"
+    "implementation_address": "0x273b65a7231321D4ee47a4c47408Ef43517455Ec"
   }
 }

--- a/config/deploy/mainnet/eth_config_input.json
+++ b/config/deploy/mainnet/eth_config_input.json
@@ -1,6 +1,6 @@
 {
   "vault_root_sender_adapter": {
-    "address": "0x0000000000000000000000000000000000000000",
+    "address": "0x9Fabd9Cc71f15b9Cfd717E117FBb9cfD9fC7cd32",
     "vault_root_sender": "0x5FDCCA53617f4d2b9134B29090C87D01058e27e9",
     "root_receiver": "0x58b5484F489f7858DC83a5a677338074b57de806",
     "root_receiver_chain": "immutable",

--- a/config/deploy/mainnet/eth_deployed.json
+++ b/config/deploy/mainnet/eth_deployed.json
@@ -8,7 +8,7 @@
     "axelar_gateway": "0x4F4495243837681061C4743b74B3eEdf548D56A5"
   },
   "stark_exchange_migration": {
-    "version": 1,
-    "implementation_address": "0x58b5484F489f7858DC83a5a677338074b57de806"
+    "version": 2,
+    "implementation_address": "0x273b65a7231321D4ee47a4c47408Ef43517455Ec"
   }
 }

--- a/config/deploy/sandbox/eth_config_input.json
+++ b/config/deploy/sandbox/eth_config_input.json
@@ -1,6 +1,6 @@
 {
   "vault_root_sender_adapter": {
-    "address": "0x0000000000000000000000000000000000000000",
+    "address": "0xCeA34C706C4A18E103575832Dd21fD3656026D1E",
     "vault_root_sender": "0x2d5C349fD8464DA06a3f90b4B0E9195F3d1b7F98",
     "root_receiver": "0x58b5484F489f7858DC83a5a677338074b57de806",
     "root_receiver_chain": "immutable",


### PR DESCRIPTION
## Summary

- Records the mainnet deployment of \`StarkExchangeMigrationV2\` at [\`0x273b65a7231321D4ee47a4c47408Ef43517455Ec\`](https://etherscan.io/address/0x273b65a7231321D4ee47a4c47408Ef43517455Ec) — bumps \`stark_exchange_migration.version\` to 2 and updates \`implementation_address\` in \`config/deploy/mainnet/eth_deployed.json\`
- Populates the already-deployed \`VaultRootSenderAdapter\` address in both mainnet and sandbox \`eth_config_input.json\` files so subsequent runs of \`DeployEthContracts.s.sol\` skip its redeployment

## Test plan

- [ ] Confirm the V2 implementation address is verified on Etherscan
- [ ] Re-run \`DeployEthContracts.s.sol\` in simulation against mainnet and confirm the script reports "Using existing" for both \`VaultRootSenderAdapter\` and \`StarkExchangeMigration v2\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only changes that update recorded on-chain addresses and versions; low risk but incorrect addresses could cause deploy scripts to target the wrong contracts.
> 
> **Overview**
> Records the mainnet deployment of **`StarkExchangeMigrationV2`** by bumping `stark_exchange_migration.version` to `2` and updating its `implementation_address` in `config/deploy/mainnet/eth_deployed.json`.
> 
> Populates already-deployed `vault_root_sender_adapter.address` values in both mainnet and sandbox `eth_config_input.json` so subsequent deploy runs reuse the existing `VaultRootSenderAdapter` instead of redeploying it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2829d2f8279b79125dbf5baaf5caf26d9e88acff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->