### PR TITLE
Use deployed StarkExchangeMigrationV2 impl in integration tests

### DIFF
--- a/test/integration/bridge/starkex/StarkExchangeMigrationV2.t.sol
+++ b/test/integration/bridge/starkex/StarkExchangeMigrationV2.t.sol
@@ -42,8 +42,12 @@ contract StarkExchangeMigrationV2IntegrationTest is Test {
     address private constant STARKEX_PROXY_OWNER = 0xD2C37fC6fD89563187f3679304975655e448D192;
     address private constant VCO_TOKEN = 0x2Caa4021e580b07D92adf8A40Ec53b33a215D620;
 
+    /// @dev Deployed StarkExchangeMigrationV2 implementation on mainnet
+    address private constant DEPLOYED_IMPL = 0x273b65a7231321D4ee47a4c47408Ef43517455Ec;
+
     /// @dev Mainnet block at which the StarkEx bridge holds VCO tokens pre-migration
-    uint256 private constant FORK_BLOCK = 24890212;
+    ///      and the StarkExchangeMigrationV2 implementation is deployed
+    uint256 private constant FORK_BLOCK = 24920000;
 
     function setUp() public {
         string memory RPC_URL = vm.envString("ETH_RPC_URL");
@@ -53,15 +57,23 @@ contract StarkExchangeMigrationV2IntegrationTest is Test {
     function _upgradeTo() internal returns (address) {
         vm.startPrank(STARKEX_PROXY_OWNER);
 
-        address newImpl = address(new StarkExchangeMigrationV2());
         bytes memory initData = bytes("");
 
-        starkExProxy.addImplementation(newImpl, initData, false);
+        starkExProxy.addImplementation(DEPLOYED_IMPL, initData, false);
         skip(15 days);
-        starkExProxy.upgradeTo(newImpl, initData, false);
+        starkExProxy.upgradeTo(DEPLOYED_IMPL, initData, false);
 
         vm.stopPrank();
-        return newImpl;
+        return DEPLOYED_IMPL;
+    }
+
+    function test_DeployedBytecodeMatchesCompiled() public {
+        address freshImpl = address(new StarkExchangeMigrationV2());
+        assertEq(
+            DEPLOYED_IMPL.code,
+            freshImpl.code,
+            "Deployed implementation bytecode should match locally compiled bytecode"
+        );
     }
 
     function test_Upgrade_ImplementationUpdated() public {


### PR DESCRIPTION
## Summary
- Reference the mainnet-deployed `StarkExchangeMigrationV2` implementation (`0x273b65a7231321D4ee47a4c47408Ef43517455Ec`) in the integration test instead of deploying a fresh instance.
- Bump `FORK_BLOCK` to `24920000` (past the deployment block 24918805).
- Add `test_DeployedBytecodeMatchesCompiled` to assert the on-chain runtime bytecode matches a locally compiled instance.

## Test plan
- [x] `ETH_RPC_URL=… forge test --match-path test/integration/bridge/starkex/StarkExchangeMigrationV2.t.sol -vv` — all 9 tests pass, including the new bytecode check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that adjust fork block/upgrade target and add a bytecode equivalence assertion; no production contract logic is modified.
> 
> **Overview**
> Integration tests now upgrade the StarkEx proxy to the **mainnet-deployed** `StarkExchangeMigrationV2` implementation (`DEPLOYED_IMPL`) instead of deploying a fresh one, and the fork block is bumped to a height where that implementation exists.
> 
> Adds `test_DeployedBytecodeMatchesCompiled` to assert the deployed runtime bytecode equals a locally compiled `StarkExchangeMigrationV2`, helping ensure the test is exercising the exact on-chain code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 090aa1a0c3464061d0cd80a954c5669beab35590. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->